### PR TITLE
Fix FontRenderer NullPointerException on Loading screen.

### DIFF
--- a/src/main/java/wtf/zani/vanillamenu/render/LoadingScreenRenderer.java
+++ b/src/main/java/wtf/zani/vanillamenu/render/LoadingScreenRenderer.java
@@ -38,7 +38,7 @@ public class LoadingScreenRenderer {
     private final int scaleFactor;
 
     private final TextureManager textureManager;
-    private final FontRenderer fontRenderer;
+    private FontRenderer fontRenderer;
     private final Framebuffer framebuffer;
     private final Minecraft minecraft;
 
@@ -78,6 +78,10 @@ public class LoadingScreenRenderer {
     }
 
     public void draw() {
+        if(fontRenderer == null)
+            fontRenderer = minecraft.fontRendererObj;   // if it's null for some reason, set it to not null
+                                                        // y'know, just an idea
+
         final int imageWidth = 256;
         final int imageHeight = 256;
 
@@ -157,20 +161,22 @@ public class LoadingScreenRenderer {
             else currentStatus = status != null ? status : "Starting Minecraft";
         }
 
-        final int stringWidth = this.fontRenderer.getStringWidth(currentStatus);
-        final float textX = (float) (displayWidth / this.scaleFactor) / 2 - (float) stringWidth / 2;
-        final float textY = (float) (displayHeight / this.scaleFactor) - 20;
+        if(fontRenderer != null) {  // for if it's still null, for some reason
+            final int stringWidth = this.fontRenderer.getStringWidth(currentStatus);
+            final float textX = (float) (displayWidth / this.scaleFactor) / 2 - (float) stringWidth / 2;
+            final float textY = (float) (displayHeight / this.scaleFactor) - 20;
 
-        this.fontRenderer.drawString(currentStatus,
-                textX,
-                textY,
-                0,
-                false);
-        this.fontRenderer.drawString(spinnerAnimation[(frame / 10) % spinnerAnimation.length],
-                textX + stringWidth + 10,
-                textY,
-                0,
-                false);
+            this.fontRenderer.drawString(currentStatus,
+                    textX,
+                    textY,
+                    0,
+                    false);
+            this.fontRenderer.drawString(spinnerAnimation[(frame / 10) % spinnerAnimation.length],
+                    textX + stringWidth + 10,
+                    textY,
+                    0,
+                    false);
+        }
 
         this.minecraft.updateDisplay();
 


### PR DESCRIPTION
Fix for a NullPointerException when launching the Forge/SkyBlock version of 1.8.9 Lunar. 

Here's the error itself, this is just a dumb fix for it, I have no idea why it could be happening, but it's fixed now.
```
java.lang.NullPointerException: Cannot invoke "net.minecraft.client.gui.FontRenderer.getStringWidth(String)" because "this.fontRenderer" is null
	at Genesis//wtf.zani.vanillamenu.render.LoadingScreenRenderer.draw(LoadingScreenRenderer.java:160)
	at Genesis//net.minecraft.client.Minecraft.handler$zzc000$drawSplashScreen(Minecraft.java:5230)
	at Genesis//net.minecraft.client.Minecraft.drawSplashScreen(Minecraft.java)
	at Genesis//net.minecraftforge.fml.client.SplashProgress.drawVanillaScreen(SplashProgress.java:819)
	at Genesis//net.minecraft.client.Minecraft.startGame(Minecraft.java:420)
	at Genesis//net.minecraft.client.Minecraft.run(Minecraft.java:329)
	at Genesis//net.minecraft.client.main.Main.main(SourceFile:124)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at com.moonsworth.lunar.genesis.Genesis.main(Unknown Source)
```